### PR TITLE
Don't write the second ImageDescription with the shaped JSON metadata

### DIFF
--- a/bin/collect_output.py
+++ b/bin/collect_output.py
@@ -136,7 +136,7 @@ def modify_and_save_img(
     new_ome_meta = modify_initial_ome_meta(
         ome_meta, segmentation_channels, pixel_size_x, pixel_size_y, pixel_unit_x, pixel_unit_y
     )
-    with tif.TiffWriter(path_to_str(out_path), bigtiff=True) as TW:
+    with tif.TiffWriter(path_to_str(out_path), bigtiff=True, shaped=False) as TW:
         TW.write(
             new_img_stack,
             contiguous=True,


### PR DESCRIPTION
The issue with the Axes being wrong in TIFF files when read into TIFFFILE was down to a second ImageDescription tag containing shaped metadata. Setting shaped=False on the TIFFWriter prevents it from being written out in the first place.